### PR TITLE
Isolated net-client dependencies

### DIFF
--- a/stundb/application/src/test/java/com/stundb/StunDBClient.java
+++ b/stundb/application/src/test/java/com/stundb/StunDBClient.java
@@ -15,7 +15,7 @@ public class StunDBClient {
 
     @SuppressWarnings("CallToPrintStackTrace")
     public static void main(String[] args) {
-        var guice = Guice.createInjector(new Module(), new ClientModule());
+        var guice = Guice.createInjector(new ClientModule());
         var executor = guice.getInstance(ExecutorService.class);
         var client = guice.getInstance(com.stundb.net.client.StunDBClient.class);
 

--- a/stundb/net/client/src/main/java/com/stundb/net/client/modules/ClientModule.java
+++ b/stundb/net/client/src/main/java/com/stundb/net/client/modules/ClientModule.java
@@ -1,9 +1,14 @@
 package com.stundb.net.client.modules;
 
 import com.google.inject.AbstractModule;
+import com.stundb.core.mappers.ApplicationConfigMapper;
+import com.stundb.core.models.ApplicationConfig;
+import com.stundb.core.modules.providers.ApplicationConfigProvider;
 import com.stundb.net.client.StunDBClient;
 import com.stundb.net.client.StunDBClientImpl;
 import com.stundb.net.client.modules.providers.ExecutorServiceProvider;
+import com.stundb.net.core.codecs.Codec;
+import com.stundb.net.core.modules.providers.CodecProvider;
 
 import java.util.concurrent.ExecutorService;
 
@@ -11,6 +16,9 @@ public class ClientModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(Codec.class).toProvider(CodecProvider.class);
+        bind(ApplicationConfigMapper.class).toInstance(ApplicationConfigMapper.INSTANCE);
+        bind(ApplicationConfig.class).toProvider(ApplicationConfigProvider.class);
         bind(ExecutorService.class).toProvider(ExecutorServiceProvider.class).asEagerSingleton();
         bind(StunDBClient.class).to(StunDBClientImpl.class);
     }

--- a/stundb/net/core/src/main/java/com/stundb/net/core/modules/providers/CodecProvider.java
+++ b/stundb/net/core/src/main/java/com/stundb/net/core/modules/providers/CodecProvider.java
@@ -15,6 +15,7 @@ import io.fury.ThreadLocalFury;
 import io.fury.config.Language;
 
 import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+@Singleton
 public class CodecProvider implements Provider<Codec> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
Isolated net-client by adding the needed bindings to ClientModule, so external clients can rely solely on the net-client and net-core modules.